### PR TITLE
Updated deprecated methods

### DIFF
--- a/src/Matrix/AsyncPromise.php
+++ b/src/Matrix/AsyncPromise.php
@@ -42,15 +42,12 @@ class AsyncPromise
     /**
      * Adds a rejection handler to the promise and returns $this for chaining.
      *
-     * The catch() method is analogous to otherwise() in ReactPHP promises.
-     *
      * @param  callable  $onRejected  The callback to execute if the promise rejects.
      * @return $this
      */
     public function catch(callable $onRejected): self
     {
-        // ReactPHP doesn't have a catch() method, but otherwise() attaches an error handler.
-        $this->promise = $this->promise->otherwise($onRejected);
+        $this->promise = $this->promise->catch($onRejected);
 
         return $this;
     }

--- a/tests/AsyncForkManagerTest.php
+++ b/tests/AsyncForkManagerTest.php
@@ -3,52 +3,8 @@
 declare(strict_types=1);
 
 use Matrix\AsyncProcessManager;
-use React\EventLoop\Loop;
-use React\Promise\PromiseInterface;
 
 uses()->group('manager', 'async');
-
-/**
- * Runs the event loop until the given promise settles or a timeout is reached.
- *
- * @param  PromiseInterface<mixed, \Throwable>  $promise  The promise to await.
- * @param  float  $timeout  Maximum time in seconds to wait.
- * @return mixed The resolved value of the promise.
- *
- * @throws \Throwable If the promise rejects.
- */
-function awaitPromise(PromiseInterface $promise, float $timeout = 2.0)
-{
-    $resolved = false;
-    $rejected = false;
-    $result = null;
-    $error = null;
-
-    $promise->then(
-        function ($val) use (&$resolved, &$result) {
-            $resolved = true;
-            $result = $val;
-            Loop::stop();
-        },
-        function ($err) use (&$rejected, &$error) {
-            $rejected = true;
-            $error = $err;
-            Loop::stop();
-        }
-    );
-
-    Loop::addTimer($timeout, function () {
-        Loop::stop();
-    });
-
-    Loop::run();
-
-    if ($rejected) {
-        throw $error;
-    }
-
-    return $result;
-}
 
 it('resolves with the child result when the callable succeeds', function () {
     $manager = new AsyncProcessManager;

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -2,6 +2,9 @@
 
 declare(strict_types=1);
 
+use React\EventLoop\Loop;
+use React\Promise\PromiseInterface;
+
 /*
 |--------------------------------------------------------------------------
 | Test Case
@@ -41,7 +44,44 @@ expect()->extend('toBeOne', function () {
 |
 */
 
-function something()
+/**
+ * Runs the event loop until the given promise settles or a timeout is reached.
+ *
+ * @param  PromiseInterface<mixed, \Throwable>  $promise  The promise to await.
+ * @param  float  $timeout  Maximum time in seconds to wait.
+ * @return mixed The resolved value of the promise.
+ *
+ * @throws \Throwable If the promise rejects.
+ */
+function awaitPromise(PromiseInterface $promise, float $timeout = 2.0)
 {
-    // ..
+    $resolved = false;
+    $rejected = false;
+    $result = null;
+    $error = null;
+
+    $promise->then(
+        function ($val) use (&$resolved, &$result) {
+            $resolved = true;
+            $result = $val;
+            Loop::stop();
+        },
+        function ($err) use (&$rejected, &$error) {
+            $rejected = true;
+            $error = $err;
+            Loop::stop();
+        }
+    );
+
+    Loop::addTimer($timeout, function () {
+        Loop::stop();
+    });
+
+    Loop::run();
+
+    if ($rejected) {
+        throw $error;
+    }
+
+    return $result;
 }


### PR DESCRIPTION
## Purpose

Refactor to use React PHP's latest stable methods.

## Approach

- Refactor React PHP `PromiseInterface` method `otherwise` to `catch` instead as it is being deprecated.